### PR TITLE
Make TLS config optional

### DIFF
--- a/config/src/main/resources/application.docker.conf
+++ b/config/src/main/resources/application.docker.conf
@@ -71,13 +71,13 @@ ubirchAvatarService {
   }
 
   kafka {
-    secureConnection = ${KAFKA_IS_SECURE_CONNECTION}
+    secureConnection = ${?KAFKA_IS_SECURE_CONNECTION}
     producer {
       bootstrapServersSecure = ${KAFKA_PROD_BOOTSTRAP_SERVERS_SSL}
-      truststoreLocation = ${KAFKA_PROD_TRUSTSTORE_LOCATION}
-      truststorePassword = ${KAFKA_PROD_TRUSTSTORE_PASS}
-      keystoreLocation = ${KAFKA_PROD_KEYSTORE_LOCATION}
-      keystorePassword = ${KAFKA_PROD_KEYSTORE_PASS}
+      truststoreLocation = ${?KAFKA_PROD_TRUSTSTORE_LOCATION}
+      truststorePassword = ${?KAFKA_PROD_TRUSTSTORE_PASS}
+      keystoreLocation = ${?KAFKA_PROD_KEYSTORE_LOCATION}
+      keystorePassword = ${?KAFKA_PROD_KEYSTORE_PASS}
       bootstrapServers = ${KAFKA_PROD_BOOTSTRAP_SERVERS}
     }
     consumer {
@@ -90,10 +90,10 @@ ubirchAvatarService {
       retryMaxRetries = ${KAFKA_CON_RETRY_MAX_RETRIES}
       parallel = ${KAFKA_CON_PARALELL}
       maxCommit = ${KAFKA_CON_MAX_COMMIT}
-      truststoreLocation = ${KAFKA_CON_TRUSTSTORE_LOCATION}
-      truststorePassword = ${KAFKA_CON_TRUSTSTORE_PASS}
-      keystoreLocation = ${KAFKA_CON_KEYSTORE_LOCATION}
-      keystorePassword = ${KAFKA_CON_KEYSTORE_PASS}
+      truststoreLocation = ${?KAFKA_CON_TRUSTSTORE_LOCATION}
+      truststorePassword = ${?KAFKA_CON_TRUSTSTORE_PASS}
+      keystoreLocation = ${?KAFKA_CON_KEYSTORE_LOCATION}
+      keystorePassword = ${?KAFKA_CON_KEYSTORE_PASS}
     }
 
     trackleEndOfLifeTopic = ${KAFKA_TRACKLE_END_OF_LIFE_TOPIC}

--- a/config/src/main/scala/com/ubirch/avatar/config/Config.scala
+++ b/config/src/main/scala/com/ubirch/avatar/config/Config.scala
@@ -171,7 +171,7 @@ object Config extends ConfigBase {
   /*
   * Kafka
    */
-  lazy val isSecureKafkaConnection: Boolean = config.getBoolean(ConfigKeys.KAFKA_IS_SECURE_CONNECTION)
+  lazy val isSecureKafkaConnection: Boolean = config.booleanWithDefault(ConfigKeys.KAFKA_IS_SECURE_CONNECTION, false)
 
   def kafkaBoostrapServer: String = if (isSecureKafkaConnection) {
     config.getString(ConfigKeys.KAFKA_PROD_BOOTSTRAP_SERVERS_SSL)
@@ -186,6 +186,7 @@ object Config extends ConfigBase {
     }
 
   def kafkaConSecureConnectionProperties: Map[String, String] = Map(
+    // These values will only be evaluated if TLS is used
     "security.protocol" -> "SSL",
     "ssl.truststore.location" -> config.getString(ConfigKeys.KAFKA_CON_TRUSTSTORE_LOCATION),
     "ssl.truststore.password" -> config.getString(ConfigKeys.KAFKA_CON_TRUSTSTORE_PASS),
@@ -194,6 +195,7 @@ object Config extends ConfigBase {
   )
 
   def kafkaProdSecureConnectionProperties: Map[String, String] = Map(
+    // These values will only be evaluated if TLS is used
     "security.protocol" -> "SSL",
     "ssl.truststore.location" -> config.getString(ConfigKeys.KAFKA_PROD_TRUSTSTORE_LOCATION),
     "ssl.truststore.password" -> config.getString(ConfigKeys.KAFKA_PROD_TRUSTSTORE_PASS),


### PR DESCRIPTION
This PR makes environment variables optional:
- KAFKA_IS_SECURE_CONNECTION (defaults to false)
- KAFKA_PROD_BOOTSTRAP_SERVERS_SSL
- KAFKA_PROD_TRUSTSTORE_LOCATION
- KAFKA_PROD_TRUSTSTORE_PASS
- KAFKA_PROD_KEYSTORE_LOCATION
- KAFKA_PROD_KEYSTORE_PASS

Since the `kafkaConSecureConnectionProperties` and `kafkaConSecureConnectionProperties` will only be evaluated if `Config.isSecureKafkaConnection`, i expect this to be safe in an environment where none of these variables are set.

Therefore the application would be compatible with the current helm chart, and no changes would be neccessary.