### PR TITLE
FIX(ci): Use maintained base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM yogihardi/alpine-scala-maven
+FROM amazoncorretto:8-alpine-jdk
 
 RUN rm -r /usr/lib/mvn
 


### PR DESCRIPTION
This is part of the CVE-2022-2068 fixes.
yogihardi/alpine-scala-maven has not been updated in years.
Switching to the Amazon corretto build of Java 8.

See: OPS-577